### PR TITLE
Fix: Signup email doesn't show link on Microsoft Email clients

### DIFF
--- a/Backend/src/views/mails/password_reset_request_email/html.html
+++ b/Backend/src/views/mails/password_reset_request_email/html.html
@@ -26,7 +26,7 @@
             </p>
             <table align="center">
                 <tr>
-                    <td align="center"><a href="{{link}}" style="cursor:pointer;border-radius:5px;font-weight: 600;font-family: arial;padding-top:8px;padding-bottom:8px;padding-left:15px;padding-right:15px;width:120px;background-color:#ff931e;color:#ffffff;text-decoration:none;mso-hide:all;">Reset password</a></td>
+                    <td align="center"><a href="{{link}}" style="cursor:pointer;border-radius:5px;font-weight: 600;font-family: arial;padding-top:8px;padding-bottom:8px;padding-left:15px;padding-right:15px;width:120px;background-color:#ff931e;color:#ffffff;text-decoration:none;">Reset password</a></td>
                 </tr>
             </table>
             <p>

--- a/Backend/src/views/mails/signup_confirm_email/html.html
+++ b/Backend/src/views/mails/signup_confirm_email/html.html
@@ -26,7 +26,7 @@
             </p>
             <table align="center">
                 <tr>
-                    <td align="center"><a href="{{link}}" style="cursor:pointer;border-radius:5px;font-weight: 600;font-family: arial;padding-top:8px;padding-bottom:8px;padding-left:15px;padding-right:15px;width:120px;background-color:#ff931e;color:#ffffff;text-decoration:none;mso-hide:all;">Click here to confirm</a></td>
+                    <td align="center"><a href="{{link}}" style="cursor:pointer;border-radius:5px;font-weight: 600;font-family: arial;padding-top:8px;padding-bottom:8px;padding-left:15px;padding-right:15px;width:120px;background-color:#ff931e;color:#ffffff;text-decoration:none;">Click here to confirm</a></td>
                 </tr>
             </table>
             <p>


### PR DESCRIPTION
Verification link was hidden on Outlook and Windows Mail because of the mso-hide CSS attribute => removed the attribute. Same problem also in the password reset email.