### PR TITLE
Added more env variables + npm scripts for local setup + fallback when mailgun key is missing

### DIFF
--- a/Backend/.gcloudignore
+++ b/Backend/.gcloudignore
@@ -19,3 +19,7 @@ node_modules/
 .vscode/
 
 cloud-run-example/
+
+.env
+
+dev/

--- a/Backend/dev/docker-compose.yml
+++ b/Backend/dev/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  database:
+    image: mongo
+    ports:
+      - 27017:27017
+  
+  minio:
+    build:
+      context: .
+      dockerfile: minio.Dockerfile
+    ports:
+      - 9000:9000
+      - 9001:9001

--- a/Backend/dev/minio.Dockerfile
+++ b/Backend/dev/minio.Dockerfile
@@ -1,0 +1,6 @@
+FROM minio/minio:latest
+
+RUN mkdir /data
+RUN mkdir /data/minio-bucket
+
+CMD ["server", "--console-address", ":9001", "/data"]

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -8,7 +8,9 @@
     "start": "node ./build/server.js",
     "gcp-build": "tsc -p .",
     "dev:start": "npm-run-all gcp-build start",
-    "dev": "nodemon --watch src -e ts,ejs --exec npm run dev:start"
+    "dev": "nodemon --watch src -e ts,ejs --exec npm run dev:start",
+    "full-backend-local:docker": "docker-compose -f dev/docker-compose.yml up -d",
+    "full-backend-local": "npm-run-all full-backend-local:docker dev"
   },
   "repository": {
     "type": "git",

--- a/Backend/src/API/REST/routes/password_reset.ts
+++ b/Backend/src/API/REST/routes/password_reset.ts
@@ -25,7 +25,9 @@ export default function password_reset_route() : Router {
       });
       await mailer.send(user.email, "[GeneCruncher] Please reset your password", "password_reset_request_email", {
         firstname: user.firstName,
-        link: `https://www.genecruncher.com/#/password_reset?token=${token.token}`
+        // link: `https://www.genecruncher.com/#/password_reset?token=${token.token}`
+        link: `${process.env.FRONTEND_URL}/#/password_reset?token=${token.token}`,
+        new_reset_link: `${process.env.FRONTEND_URL}/password_reset`
       })
 
       return res.status(200).send('An email has been sent to your email address with instructions to reset your password');
@@ -54,7 +56,8 @@ export default function password_reset_route() : Router {
       // send pw-update email
       await mailer.send(user.email, "[GeneCruncher] Your password was successfully reset", "password_reset_confirmation_email", {
         firstname: user.firstName,
-        email: user.email
+        email: user.email,
+        link: `${process.env.FRONTEND_URL}/password_reset`
       });
 
       return res.status(200).send("Password has been changed");

--- a/Backend/src/API/REST/routes/verify_email.ts
+++ b/Backend/src/API/REST/routes/verify_email.ts
@@ -22,7 +22,8 @@ export default function verify_email(): Router {
 
             user.isEmailVerified = true;
             await user.save();
-            res.status(200).send("<h2>User Email has been verified successfully. click <a href='https://www.genecruncher.com/'>here</a> to return</h2>");
+            // res.status(200).send("<h2>User Email has been verified successfully. click <a href='https://www.genecruncher.com/'>here</a> to return</h2>");
+            res.status(200).send(`<h2>User Email has been verified successfully. click <a href='${process.env.FRONTEND_URL}/'>here</a> to return</h2>`);
             tokenObj.delete();
         }))
 

--- a/Backend/src/startup/init_env_vars.ts
+++ b/Backend/src/startup/init_env_vars.ts
@@ -13,6 +13,9 @@ export function init_env_vars() {
         "S3_BUCKET_NAME",
         "MAILGUN_API_KEY",
         "MAIL_DOMAIN",
+        "MAILGUN_HOST",
+        "API_URL",
+        "FRONTEND_URL",
         "JWT_SECRET"
     ];
     required_env_vars.forEach((required_env_var) => {
@@ -28,9 +31,13 @@ export function init_env_vars() {
 
     setStdEnvValue("PORT", "8050");
     setStdEnvValue("DATABASE_URI", "mongodb://localhost:27017/dev");
+    setStdEnvValue("API_URL","http://localhost:8050");
+    setStdEnvValue("FRONTEND_URL","http://localhost:3000");
 
     setStdEnvValue("JWT_SECRET", String(Math.random()));
 
-    setStdEnvValue("S3_ENDPOINT", "http://127.0.0.1:9000");
-    setStdEnvValue("S3_BUCKET_NAME", "vaultgovsg");
+    setStdEnvValue("S3_ENDPOINT", "http://localhost:9000");
+    setStdEnvValue("S3_BUCKET_NAME", "minio-bucket");
+    setStdEnvValue("S3_ACCESS_KEY_ID", "minioadmin");
+    setStdEnvValue("S3_SECRET_ACCESS_KEY", "minioadmin");
 }

--- a/Backend/src/util/mailer.ts
+++ b/Backend/src/util/mailer.ts
@@ -6,16 +6,22 @@ import fs from "fs/promises";
 import handlebars from "handlebars";
 
 class Mailer {
-    transport : nodemailer.Transporter;
+    transport: nodemailer.Transporter | null;
 
-    constructor(){
-        this.transport = nodemailer.createTransport(mailgunTransport({
-            auth: {
-                api_key: process.env.MAILGUN_API_KEY!,
-                domain: process.env.MAIL_DOMAIN
-            },
-            host: process.env.MAILGUN_HOST
-        }));
+    constructor() {
+        if (!process.env.MAILGUN_API_KEY || process.env.MAILGUN_API_KEY == "") {
+            this.transport = null;
+        } else {
+            this.transport = nodemailer.createTransport(
+                mailgunTransport({
+                    auth: {
+                        api_key: process.env.MAILGUN_API_KEY!,
+                        domain: process.env.MAIL_DOMAIN
+                    },
+                    host: process.env.MAILGUN_HOST
+                })
+            );
+        }
     }
 
     async send(to : string, subject : string, template_name : string, data : any) {
@@ -25,13 +31,24 @@ class Mailer {
 
         let rendered_txt = handlebars.compile(texttemplate)(data);
         let rendered_html = handlebars.compile(htmltemplate)(data);
-        return self.transport.sendMail({
+
+        let mail = {
             from: `GeneCruncher <info@${process.env.MAIL_DOMAIN}>`,
             to: to,
             subject: subject,
             text: rendered_txt,
             html: rendered_html
-        });
+        };
+        if (!self.transport) {
+            console.log("No mailgun key provided: logging email here:");
+            console.log(`From: ${mail.from}`);
+            console.log(`To: ${mail.to}`);
+            console.log(`Subject: ${mail.subject}`);
+            console.log(`Text: ${mail.text}`);
+            console.log(`HTML: ${mail.html}`);
+        } else {
+            return self.transport.sendMail(mail);
+        }
     }
 
     async send_verification_mail(firstname: string, recipient: string, token: string) {

--- a/Backend/src/util/mailer.ts
+++ b/Backend/src/util/mailer.ts
@@ -14,7 +14,7 @@ class Mailer {
                 api_key: process.env.MAILGUN_API_KEY!,
                 domain: process.env.MAIL_DOMAIN
             },
-            host: "api.eu.mailgun.net"
+            host: process.env.MAILGUN_HOST
         }));
     }
 
@@ -35,7 +35,8 @@ class Mailer {
     }
 
     async send_verification_mail(firstname: string, recipient: string, token: string) {
-        return this.send(recipient, "Verify Email", "signup_confirm_email", {link: `https://api.genecruncher.com/verify/${token}`, firstname:firstname})
+        // return this.send(recipient, "Verify Email", "signup_confirm_email", {link: `https://api.genecruncher.com/verify/${token}`, firstname:firstname})
+        return this.send(recipient, "Verify Email", "signup_confirm_email", {link: `${process.env.API_URL}/verify/${token}`, firstname:firstname})
     }
 }
 

--- a/Backend/src/views/mails/password_reset_confirmation_email/html.html
+++ b/Backend/src/views/mails/password_reset_confirmation_email/html.html
@@ -25,7 +25,7 @@
             <h5>We wanted to let you know that your GeneCruncher password was reset.</h5>
             </p>
             <p>
-            <h5>If you did not perform this action, you can recover access by entering {{email}} into the form at <a href='https://www.genecruncher.com/password_reset'>https://www.genecruncher.com/password_reset</a></h5>
+            <h5>If you did not perform this action, you can recover access by entering {{email}} into the form at <a href='{{link}}'>{{link}}</a></h5>
             <h5>Thanks,</h5>
             <h5>The GeneCruncher Team</h5>
             </p>

--- a/Backend/src/views/mails/password_reset_confirmation_email/text.txt
+++ b/Backend/src/views/mails/password_reset_confirmation_email/text.txt
@@ -3,7 +3,7 @@ Your password was reset
 Hey {{firstname}},
 We wanted to let you know that your GeneCruncher password was reset.
 
-If you did not perform this action, you can recover access by entering {{email}} into the form at https://www.genecruncher.com/password_reset
+If you did not perform this action, you can recover access by entering {{email}} into the form at {{link}}
 
 Thanks,
 The GeneCruncher Team

--- a/Backend/src/views/mails/password_reset_request_email/html.html
+++ b/Backend/src/views/mails/password_reset_request_email/html.html
@@ -30,7 +30,7 @@
                 </tr>
             </table>
             <p>
-            <h5>If you don't use this link within 3 hours, it will expire. To get a new password reset link, visit: <a href='https://www.genecruncher.com/password_reset'>https://www.genecruncher.com/password_reset</a></h5>
+            <h5>If you don't use this link within 3 hours, it will expire. To get a new password reset link, visit: <a href='{{new_reset_link}}'>{{new_reset_link}}</a></h5>
             <h5>Thanks,</h5>
             <h5>The GeneCruncher Team</h5>
             </p>

--- a/Backend/src/views/mails/password_reset_request_email/text.txt
+++ b/Backend/src/views/mails/password_reset_request_email/text.txt
@@ -5,7 +5,7 @@ we heard that you lost your GeneCruncher password. Sorry about that!
 
 But don't worry! You can use the following link to reset your password: {{link}}
 
-If you don't use this link within 3 hours, it will expire. To get a new password reset link, visit: https://www.genecruncher.com/password_reset
+If you don't use this link within 3 hours, it will expire. To get a new password reset link, visit: {{new_reset_link}}
 
 Thanks,
 The GeneCruncher Team


### PR DESCRIPTION
Improved the environment setup, so it is easier to completely run locally.

Replaced some hardcoded URLs/domains with environment variables.

New environment variables:

- MAILGUN_HOST (in case a Mailgun account runs on api.mailgun.net instead of api.eu.mailgun.net)
- API_URL (was "https://api.genecruncher.com", can now be set to localhost etc.)
- FRONTEND_URL (was "https://genecruncher.com", can now be set to localhost etc.)

Added a docker-compose file which starts a minio s3 instance and a mongodb instance
Added a npm script which

1. starts the docker compose for the s3 and mongodb and
2. starts the backend server without docker, using nodemon (added by @Pellumbengineer)