### PR TITLE
Feature/b 55 discuss double referencing

### DIFF
--- a/Backend/src/API/REST/routes/team/teamRouter.ts
+++ b/Backend/src/API/REST/routes/team/teamRouter.ts
@@ -153,11 +153,7 @@ const add_project_to_team = (): Router => {
         return res.status(401).send("User is not the project owner!");
 
       try {
-        const team_updated = await TeamService.addProject(teamId, projectId);
         const project_updated = await ProjectService.setTeamOfProject(projectId, teamId);
-
-        if (!team_updated)
-          return res.status(500).send("Error when adding the project to project list of the team.");
 
         if (!project_updated)
           return res.status(500).send("Error when setting the team id of the project.");
@@ -171,7 +167,7 @@ const add_project_to_team = (): Router => {
       }
     } catch (e) {
       /* Added since a test proved that if user sends a request with incorrect parameter names, it is able to shutdown the server. */
-      console.error("Error in invite_person_to_a_project()");
+      console.error("Error in add_project_to_team()");
       console.error(JSON.stringify(e));
       console.error(e);
       return res.status(500).send("Internal error.");

--- a/Backend/src/database/models/team.ts
+++ b/Backend/src/database/models/team.ts
@@ -11,7 +11,6 @@ export interface ITeam extends Document {
   adminIds: Array<Schema.Types.ObjectId>;
   invitedMemberIds: Array<Schema.Types.ObjectId>;
   memberIds: Array<Schema.Types.ObjectId>;
-  projects: Array<Schema.Types.ObjectId>;
   visibility: string;
   institutionId: Schema.Types.ObjectId;
 }
@@ -48,14 +47,6 @@ const teamSchema = new Schema<ITeam>(
       {
         type: Schema.Types.ObjectId,
         ref: "User",
-        require: false,
-      },
-    ],
-
-    projects: [
-      {
-        type: Schema.Types.ObjectId,
-        ref: "Project",
         require: false,
       },
     ],

--- a/Backend/src/database/services/team.service.ts
+++ b/Backend/src/database/services/team.service.ts
@@ -73,19 +73,6 @@ export default class TeamService {
   }
 
   /**
-   *  Add the given projectId to the project list of the given team.
-   *
-   *  FIXME delete this method
-   *
-   *  @param   teamId
-   *  @param   projectId
-   *  @returns updateDocument
-   */
-  static async addProject(teamId: ObjectId | string, projectId: ObjectId | string): Promise<any> {
-    return await teamModel.updateOne({ _id: teamId }, { $addToSet: { projects: projectId } });
-  }
-
-  /**
    *  Add the given userId to the admin list and removes he/she from the memberIds, of the given team.
    *
    *  @param   teamId

--- a/Backend/src/database/services/team.service.ts
+++ b/Backend/src/database/services/team.service.ts
@@ -5,7 +5,7 @@ import { ObjectId } from "mongoose";
 /**
  *  @class TeamService
  *
- *  Provides useful methods to access the database and modify projects,
+ *  Provides useful methods to access the database and modify teams,
  *  which can be used by the route-controllers.
  */
 export default class TeamService {
@@ -13,7 +13,7 @@ export default class TeamService {
    *  Adds given team to the database.
    *
    *  @param    team
-   *  @returns  projectAdded - the added team
+   *  @returns  teamAdded - the added team
    */
   static async addTeam(team: AddTeamDTO): Promise<ITeam> {
     let teamAdded: ITeam | undefined = undefined;
@@ -25,7 +25,7 @@ export default class TeamService {
    *  Search for a team with the given title and return if found.
    *
    *  @param   title
-   *  @returns project or null
+   *  @returns team or null
    */
   static async getTeamByTitle(title: string): Promise<(ITeam & { _id: ObjectId }) | null> {
     return await teamModel.findOne({ title });
@@ -35,7 +35,7 @@ export default class TeamService {
    *  Search for a team with the given team id and return if found.
    *
    *  @param   teamId
-   *  @returns project - matched proejct to projectId or null
+   *  @returns team - matched team to teamId or null
    */
   static async getTeamById(teamId: ObjectId | string): Promise<(ITeam & { _id: ObjectId }) | null> {
     return await teamModel.findById(teamId).exec();
@@ -74,6 +74,8 @@ export default class TeamService {
 
   /**
    *  Add the given projectId to the project list of the given team.
+   *
+   *  FIXME delete this method
    *
    *  @param   teamId
    *  @param   projectId
@@ -144,7 +146,7 @@ export default class TeamService {
   }
 
   /**
-   *  Add the given userId into the given project.
+   *  Add the given userId into the given team.
    *
    *  @param   teamId
    *  @param   userId
@@ -213,7 +215,7 @@ export default class TeamService {
   }
 
   /**
-   *  Remove the given userId into the given project.
+   *  Remove the given userId from the given team.
    *
    *  @param   teamId
    *  @param   userId


### PR DESCRIPTION
Project list property is removed from Team model because it was causing double referencing with the team list property of Project model.