### PR TITLE
Added /atlas/:id/visualization route

### DIFF
--- a/Backend/src/API/REST/express_routes.ts
+++ b/Backend/src/API/REST/express_routes.ts
@@ -25,7 +25,7 @@ import upload_user_avatar_route from "./routes/upload_user_avatar";
 
 import { get_teams_of_user, get_users } from "./routes/user/userRouter";
 import { get_model, get_allModels } from "./routes/model/modelRouter";
-import { get_atlas, get_allAtlases } from "./routes/atlas/atlasRouter";
+import { get_atlas, get_atlas_visualization, get_allAtlases } from "./routes/atlas/atlasRouter";
 import * as swaggerDocument from "../../swagger.json";
 import * as swaggerUi from "swagger-ui-express";
 
@@ -137,6 +137,7 @@ export function express_routes(this: REST_Host): Router {
 
   // atlas routes
   this.expressApp.use(get_atlas());
+  this.expressApp.use(get_atlas_visualization());
   this.expressApp.use(get_allAtlases());
 
   // upload routes

--- a/Backend/src/swagger.json
+++ b/Backend/src/swagger.json
@@ -1742,6 +1742,42 @@
         }
       }
     },
+    "/atlas/{id}/visualization": {
+      "get": {
+        "summary": "Receive a URL to the file used for visualization of an atlas",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Atlas"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful retrieval of the URL",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Atlas with id does not exist"
+          },
+          "500": {
+            "description": "Internal error"
+          }
+        }
+      }
+    },
     "/models": {
       "get": {
         "summary": "Get all available models",
@@ -1799,7 +1835,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                  "type": "object",
+                    "type": "object",
                     "properties": {
                       "_id": {
                         "type": "string"


### PR DESCRIPTION
This route returns a url to the csv file, with which the atlas data itself can be visualized by frontend.