### PR TITLE
Change login&signup modals

### DIFF
--- a/Frontend/src/components/Input/Input.jsx
+++ b/Frontend/src/components/Input/Input.jsx
@@ -31,8 +31,7 @@ import { colors } from 'shared/theme/colors';
  */
 const Input = (props) => { 
 
-  const {helperText, placeholder, errorHandler, disabledHandler, isRequired=true, defaultValue, multiline=false, onChangeEvent=null, label='Required', maxLength=40, type='text'} = props
-  
+  const {id,helperText, placeholder, errorHandler, disabledHandler, isRequired=false, defaultValue, multiline=false, onChangeEvent=null, label='Required', maxLength=40, type='text'} = props
   return (
   <Box
     component="form"
@@ -52,12 +51,12 @@ const Input = (props) => {
       inputProps={{ maxLength }}
       multiline={multiline}
       type={type}
-      id="input"
+      id={id}
       rows={4}
       label={label}
       helperText={helperText}
       variant="standard"
-      onChange={(e) => (onChangeEvent !== null ? onChangeEvent(e.target.value) : null)}
+      onChange={(e) => (onChangeEvent !== null ? onChangeEvent(e) : null)}
     />
   </Box>
 )};

--- a/Frontend/src/components/LoginForm/index.jsx
+++ b/Frontend/src/components/LoginForm/index.jsx
@@ -1,17 +1,14 @@
 /* eslint-disable */
 import {
   Alert,
-  Avatar,
   Box,
   Checkbox,
   FormControlLabel,
   Grid,
   Snackbar,
-  TextField,
   Typography,
   Link,
 } from "@mui/material";
-import LoadingButton from "@mui/lab/LoadingButton";
 import React, { useCallback, useState } from "react";
 import validator from "validator";
 import CloseIcon from "@mui/icons-material/Close";
@@ -24,6 +21,7 @@ import { useAuth } from "shared/context/authContext";
 import { Modal, ModalTitle } from "components/Modal";
 import Input from "components/Input/Input";
 import CustomButton from "components/CustomButton";
+import { colors } from 'shared/theme/colors';
 
 function LoginForm(props) {
   const [, setUser] = useAuth();
@@ -187,29 +185,31 @@ function LoginForm(props) {
               isRequired={true}
               onChangeEvent={handleTextChange}
             />
-            <Box sx={{paddingLeft:2}}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  id="remember"
-                  color="primary"
-                  onChange={handleCheckedChange}
-                />
-              }
-              label="Remember me"
-            />
-            <CustomButton type="contained" sx={{ mr: 1 }} onClick={doLogin}>
-              <Typography>Sign in</Typography>
-            </CustomButton>
-            <Typography mt={1}>
-              <Link
-                href="#"
-                onClick={handlepasswordForget}
-                className={styles.pwReminderLink}
-              >
-                Forgot password?
-              </Link>
-            </Typography>
+            <Box sx={{ paddingLeft: 1, display: "flex", flexDirection: "column", gap: "4   px" }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    id="remember"
+                    sx={{ color: colors.primary[400], '& .MuiSvgIcon-root': { color: colors.primary[400] } }}
+                    onChange={handleCheckedChange}
+                    disableRipple
+                    disableFocusRipple
+                  />
+                }
+                label="Remember me"
+              />
+              <CustomButton type="primary" onClick={doLogin}>
+                <Typography>Sign in</Typography>
+              </CustomButton>
+              <Typography mt={1}>
+                <Link
+                  href="#"
+                  onClick={handlepasswordForget}
+                  className={styles.pwReminderLink}
+                >
+                  Forgot password?
+                </Link>
+              </Typography>
             </Box>
           </Grid>
 

--- a/Frontend/src/components/LoginForm/index.jsx
+++ b/Frontend/src/components/LoginForm/index.jsx
@@ -1,24 +1,35 @@
 /* eslint-disable */
 import {
   Alert,
-  Avatar, Box, Checkbox, FormControlLabel, Grid, Modal, Snackbar, TextField, Typography, Link,
-} from '@mui/material';
-import LoadingButton from '@mui/lab/LoadingButton';
-import React, { useCallback, useState } from 'react';
-import validator from 'validator';
-import CloseIcon from '@mui/icons-material/Close';
-import { useHistory } from 'react-router-dom';
-import logo from 'assets/logo.svg';
-import styles from './loginform.module.css';
-import { BACKEND_ADDRESS } from 'shared/utils/common/constants';
-import PasswordForgetForm from '../PasswordForgetForm';
-import { useAuth } from 'shared/context/authContext';
+  Avatar,
+  Box,
+  Checkbox,
+  FormControlLabel,
+  Grid,
+  Snackbar,
+  TextField,
+  Typography,
+  Link,
+} from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
+import React, { useCallback, useState } from "react";
+import validator from "validator";
+import CloseIcon from "@mui/icons-material/Close";
+import { useHistory } from "react-router-dom";
+import logo from "assets/logo.svg";
+import styles from "./loginform.module.css";
+import { BACKEND_ADDRESS } from "shared/utils/common/constants";
+import PasswordForgetForm from "../PasswordForgetForm";
+import { useAuth } from "shared/context/authContext";
+import { Modal, ModalTitle } from "components/Modal";
+import Input from "components/Input/Input";
+import CustomButton from "components/CustomButton";
 
 function LoginForm(props) {
   const [, setUser] = useAuth();
   const [loginDetails, setLoginDetails] = useState({
-    email: '',
-    password: '',
+    email: "",
+    password: "",
     remember: false,
   });
 
@@ -31,8 +42,8 @@ function LoginForm(props) {
 
   const onClose = useCallback(() => {
     setLoginDetails({
-      email: '',
-      password: '',
+      email: "",
+      password: "",
       remember: false,
     });
     setErrors({});
@@ -40,13 +51,25 @@ function LoginForm(props) {
     props.onClose();
   }, [setLoginDetails, setErrors, setLoading, props]);
 
-  const handleTextChange = useCallback((e) => {
-    setLoginDetails((prevState) => ({ ...prevState, [e.target.id]: e.target.value }));
-  }, [setLoginDetails]);
+  const handleTextChange = useCallback(
+    (e) => {
+      setLoginDetails((prevState) => ({
+        ...prevState,
+        [e.target.id]: e.target.value,
+      }));
+    },
+    [setLoginDetails]
+  );
 
-  const handleCheckedChange = useCallback((e) => {
-    setLoginDetails((prevState) => ({ ...prevState, [e.target.id]: e.target.checked }));
-  }, [setLoginDetails]);
+  const handleCheckedChange = useCallback(
+    (e) => {
+      setLoginDetails((prevState) => ({
+        ...prevState,
+        [e.target.id]: e.target.checked,
+      }));
+    },
+    [setLoginDetails]
+  );
 
   const handlepasswordForget = useCallback(() => {
     onClose();
@@ -56,33 +79,45 @@ function LoginForm(props) {
   function validateInput() {
     let currentErrors = {};
     if (!validator.isEmail(loginDetails.email)) {
-      currentErrors = { ...currentErrors, email: 'A valid e-mail is required!' };
+      currentErrors = {
+        ...currentErrors,
+        email: "A valid e-mail is required!",
+      };
     }
-    if (loginDetails.password === '') {
-      currentErrors = { ...currentErrors, password: 'Password is required!' };
+    if (loginDetails.password === "") {
+      currentErrors = { ...currentErrors, password: "Password is required!" };
     }
     setErrors(currentErrors);
     return !Object.keys(currentErrors).length;
   }
 
   async function onSuccessfulLogin(data) {
-    localStorage.setItem('jwt', data.jwt);
-    localStorage.setItem('user', JSON.stringify(data.user));
+    localStorage.setItem("jwt", data.jwt);
+    localStorage.setItem("user", JSON.stringify(data.user));
     onClose();
     await setUser(data.user);
-    history.push('/sequencer/genemapper');
+    history.push("/sequencer/genemapper");
   }
 
   function onFailedLogin(code) {
     switch (code) {
       case 401:
-        setErrors((prevState) => ({ ...prevState, response: 'Wrong credentials!' }));
+        setErrors((prevState) => ({
+          ...prevState,
+          response: "Wrong credentials!",
+        }));
         break;
       case 404:
-        setErrors((prevState) => ({ ...prevState, response: 'User not found!' }));
+        setErrors((prevState) => ({
+          ...prevState,
+          response: "User not found!",
+        }));
         break;
       default:
-        setErrors((prevState) => ({ ...prevState, response: 'Unknown error, please try again later!' }));
+        setErrors((prevState) => ({
+          ...prevState,
+          response: "Unknown error, please try again later!",
+        }));
         break;
     }
   }
@@ -94,20 +129,20 @@ function LoginForm(props) {
     setLoading(true);
     // server communication
     const loginRequest = {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer',
+        "Content-Type": "application/json",
+        Authorization: "Bearer",
       },
       body: JSON.stringify({
         email: loginDetails.email,
         password: loginDetails.password,
       }),
     };
-    console.log(BACKEND_ADDRESS)
+    console.log(BACKEND_ADDRESS);
     fetch(`${BACKEND_ADDRESS}/auth`, loginRequest)
-    .then((response) => {
-      setLoading(false);
+      .then((response) => {
+        setLoading(false);
         setSnackbarVisible(true);
         if (response.status !== 200) {
           onFailedLogin(response.status);
@@ -122,87 +157,62 @@ function LoginForm(props) {
       });
   }, [setLoading, loginDetails, setErrors]);
 
-  const boxStyle = {
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-    width: 400,
-    bgcolor: 'background.paper',
-    boxShadow: 24,
-    p: 4,
-    borderRadius: 3,
-  };
-
   const { close, visible } = props;
+  const [isOpen, setIsOpen] = useState(false);
 
+  console.log(loginDetails);
   return (
     <div>
-      <Modal
-        onClose={close}
-        open={visible}
-        aria-labelledby="simple-modal-title"
-        aria-describedby="simple-modal-description"
-      >
-        <Box sx={boxStyle}>
-          <Grid>
-            <Grid container direction="row" justifyContent="center">
-              <Grid xs item />
-              <Grid align="center">
-                <Avatar src={logo} sx={{ width: 72, height: 72 }} />
-                <h2>Sign In</h2>
-              </Grid>
-              <Grid xs align="right" item>
-                <CloseIcon onClick={onClose} className={styles.closeImg} />
-              </Grid>
-            </Grid>
-            <TextField
+      <Modal setOpen={(o) => !o && onClose()} isOpen={visible}>
+        <ModalTitle>Log in</ModalTitle>
+        <Box sx={{ width:340}}>
+          <Grid sx={{width:320}}>
+            <Input
               id="email"
               type="email"
               error={!!errors.email}
               helperText={errors.email}
               label="E-mail"
               placeholder="Enter e-mail address"
-              fullWidth
-              required
-              onChange={handleTextChange}
+              isRequired={true}
+              onChangeEvent={handleTextChange}
             />
-            <TextField
+            <Input
               id="password"
               error={!!errors.password}
               helperText={errors.password}
               label="Password"
               type="password"
-              margin="dense"
               placeholder="Enter password"
-              fullWidth
-              required
-              onChange={handleTextChange}
+              isRequired={true}
+              onChangeEvent={handleTextChange}
             />
+            <Box sx={{paddingLeft:2}}>
             <FormControlLabel
-              control={(
+              control={
                 <Checkbox
                   id="remember"
                   color="primary"
                   onChange={handleCheckedChange}
                 />
-              )}
+              }
               label="Remember me"
             />
-            <LoadingButton
-              loading={loading}
-              type="submit"
-              color="primary"
-              variant="contained"
-              fullWidth
-              onClick={doLogin}
-            >
-              Sign in
-            </LoadingButton>
+            <CustomButton type="contained" sx={{ mr: 1 }} onClick={doLogin}>
+              <Typography>Sign in</Typography>
+            </CustomButton>
             <Typography mt={1}>
-              <Link href="#" onClick={handlepasswordForget} className={styles.pwReminderLink}>Forgot password?</Link>
+              <Link
+                href="#"
+                onClick={handlepasswordForget}
+                className={styles.pwReminderLink}
+              >
+                Forgot password?
+              </Link>
             </Typography>
+            </Box>
           </Grid>
+
         </Box>
       </Modal>
       <Snackbar
@@ -211,14 +221,17 @@ function LoginForm(props) {
         onClose={() => setSnackbarVisible(false)}
       >
         <Alert
-          severity={errors.response ? 'error' : 'success'}
-          sx={{ width: '100%' }}
+          severity={errors.response ? "error" : "success"}
+          sx={{ width: "100%" }}
           onClose={() => setSnackbarVisible(false)}
         >
-          {errors.response ? errors.response : 'Login successful!'}
+          {errors.response ? errors.response : "Login successful!"}
         </Alert>
       </Snackbar>
-      <PasswordForgetForm visible={forgotPassword} onClose={() => setForgotPassword(false)} />
+      <PasswordForgetForm
+        visible={forgotPassword}
+        onClose={() => setForgotPassword(false)}
+      />
     </div>
   );
 }

--- a/Frontend/src/components/RegistrationForm/index.jsx
+++ b/Frontend/src/components/RegistrationForm/index.jsx
@@ -61,7 +61,7 @@ function RegistrationForm(props) {
     });
     setErrors({});
     setLoading(false);
-    onClose();
+    props.onClose();
   }, [setUserDetails, setErrors, setLoading, props, setUser]);
 
   function onSuccessfulRegistration() {

--- a/Frontend/src/components/RegistrationForm/index.jsx
+++ b/Frontend/src/components/RegistrationForm/index.jsx
@@ -1,14 +1,10 @@
 import {
-  Avatar, Typography, Box, Grid, Snackbar, TextField,
+  Typography, Box, Grid, Snackbar, TextField,
 } from '@mui/material';
-import LoadingButton from '@mui/lab/LoadingButton';
 import React, { useCallback, useState } from 'react';
 import validator from 'validator';
-import CloseIcon from '@mui/icons-material/Close';
 import { Alert } from '@mui/lab';
 import { BACKEND_ADDRESS } from 'shared/utils/common/constants';
-import logo from 'assets/logo.svg';
-import styles from './registrationform.module.css';
 import { useAuth } from 'shared/context/authContext';
 import Input from 'components/Input/Input';
 import { Modal, ModalTitle } from 'components/Modal';
@@ -65,12 +61,12 @@ function RegistrationForm(props) {
     });
     setErrors({});
     setLoading(false);
-    props.onClose();
+    onClose();
   }, [setUserDetails, setErrors, setLoading, props, setUser]);
 
   function onSuccessfulRegistration() {
     onClose();
-    props.onSuccessfulRegistration();
+    setSnackbarVisible(true)
   }
 
   function onFailedRegistration(response) {
@@ -126,8 +122,8 @@ function RegistrationForm(props) {
         isOpen={visible}
       >
         <ModalTitle>Register new user</ModalTitle>
-        <Box sx={{ width: 340 }}>
-          <Grid sx={{ width: 320 }}>
+        <Box sx={{ width: 500 }}>
+          <Grid sx={{ width: "90%", margin: "auto"}}>
             <Input
               id="email"
               type="email"
@@ -188,7 +184,7 @@ function RegistrationForm(props) {
               onChangeEvent={handleTextChange}
             />
             <Box mt={1}>
-              <CustomButton type="contained" sx={{ mr: 1 }} onClick={doRegistration}>
+              <CustomButton type="primary" sx={{ mr: "auto", width: "100%" }} onClick={doRegistration}>
                 <Typography>Sign up</Typography>
               </CustomButton>
             </Box>

--- a/Frontend/src/components/RegistrationForm/index.jsx
+++ b/Frontend/src/components/RegistrationForm/index.jsx
@@ -1,5 +1,5 @@
 import {
-  Avatar, Box, Grid, Modal, Snackbar, TextField,
+  Avatar, Typography, Box, Grid, Snackbar, TextField,
 } from '@mui/material';
 import LoadingButton from '@mui/lab/LoadingButton';
 import React, { useCallback, useState } from 'react';
@@ -10,6 +10,9 @@ import { BACKEND_ADDRESS } from 'shared/utils/common/constants';
 import logo from 'assets/logo.svg';
 import styles from './registrationform.module.css';
 import { useAuth } from 'shared/context/authContext';
+import Input from 'components/Input/Input';
+import { Modal, ModalTitle } from 'components/Modal';
+import CustomButton from 'components/CustomButton';
 
 function RegistrationForm(props) {
   const [, setUser] = useAuth();
@@ -114,122 +117,80 @@ function RegistrationForm(props) {
       });
   }, [userDetails, setErrors, setLoading, props, setSnackbarVisible, setUser]);
 
-  const boxStyle = {
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-    width: 400,
-    bgcolor: 'background.paper',
-    boxShadow: 24,
-    p: 4,
-    borderRadius: 3,
-  };
-
   const { close, visible } = props;
 
   return (
     <div>
       <Modal
-        onClose={close}
-        open={visible}
-        aria-labelledby="simple-modal-title"
-        aria-describedby="simple-modal-description"
+        setOpen={(o) => !o && onClose()}
+        isOpen={visible}
       >
-        <Box sx={boxStyle}>
-          <Grid>
-            <Grid container direction="row" justifyContent="center">
-              <Grid xs item />
-              <Grid align="center">
-                <Avatar src={logo} sx={{ width: 72, height: 72 }} />
-                <h2>Register new account</h2>
-              </Grid>
-              <Grid xs align="right" item>
-                <CloseIcon onClick={onClose} className={styles.closeImg} />
-              </Grid>
-            </Grid>
-            <TextField
+        <ModalTitle>Register new user</ModalTitle>
+        <Box sx={{ width: 340 }}>
+          <Grid sx={{ width: 320 }}>
+            <Input
               id="email"
               type="email"
               error={!!errors.email}
               helperText={errors.email}
               label="E-mail"
               placeholder="Enter e-mail address"
-              fullWidth
-              required
-              margin="dense"
-              onChange={handleTextChange}
+              isRequired
+              onChangeEvent={handleTextChange}
             />
-            <TextField
+            <Input
               id="firstname"
               type="text"
               error={!!errors.firstname}
               helperText={errors.firstname}
               label="First name"
               placeholder="Enter your first name"
-              margin="dense"
-              fullWidth
-              required
-              onChange={handleTextChange}
+              isRequired
+              onChangeEvent={handleTextChange}
             />
-            <TextField
+            <Input
               id="lastname"
               type="text"
               error={!!errors.lastname}
               helperText={errors.lastname}
               label="Last name"
               placeholder="Enter your last name"
-              margin="dense"
-              fullWidth
-              required
-              onChange={handleTextChange}
+              isRequired
+              onChangeEvent={handleTextChange}
             />
-            <TextField
+            <Input
               id="affiliation"
               error={!!errors.affiliation}
               helperText={errors.affiliation}
               label="Academic affiliation"
               type="text"
               placeholder="Enter your university, company or etc."
-              margin="dense"
-              fullWidth
-              onChange={handleTextChange}
+              onChangeEvent={handleTextChange}
             />
-            <TextField
+            <Input
               id="password"
               error={!!errors.password}
               helperText={errors.password}
               label="Password"
               type="password"
               placeholder="Enter password"
-              margin="dense"
-              fullWidth
-              required
-              onChange={handleTextChange}
+              isRequired
+              onChangeEvent={handleTextChange}
             />
-            <TextField
+            <Input
               id="passwordAgain"
               error={!!errors.passwordAgain}
               helperText={errors.passwordAgain}
               label="Password again"
               type="password"
               placeholder="Enter your password again"
-              margin="dense"
-              fullWidth
-              required
-              onChange={handleTextChange}
+              isRequired
+              onChangeEvent={handleTextChange}
             />
             <Box mt={1}>
-              <LoadingButton
-                loading={loading}
-                type="submit"
-                color="primary"
-                variant="contained"
-                fullWidth
-                onClick={doRegistration}
-              >
-                Sign up
-              </LoadingButton>
+              <CustomButton type="contained" sx={{ mr: 1 }} onClick={doRegistration}>
+                <Typography>Sign up</Typography>
+              </CustomButton>
             </Box>
           </Grid>
         </Box>


### PR DESCRIPTION
When signup is successful, a useful tooltip should be shown to let the user know that everything went great and to check their mailbox and confirm their email.

Also a weird bug: When logging in with 1 account and then signing out and logging with a second account, the first one shows up, as if the first account is not deleted by localStorage. Need to take a look at this