### PR TITLE
Fix / Delete profile cache on logout

### DIFF
--- a/Frontend/src/components/Sidebar/index.jsx
+++ b/Frontend/src/components/Sidebar/index.jsx
@@ -10,6 +10,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import LogoutIcon from '@mui/icons-material/Logout';
 import geneIcon from 'assets/gene.png';
 import styles from './sidebar.module.css';
+import ProfileService from 'shared/services/Profile.service';
 
 function indexIcon(index) {
   switch (index) {
@@ -92,6 +93,7 @@ export default function Sidebar(props) {
                 to="/"
                 onClick={() => {
                   setUser(null);
+                  ProfileService.clearProfileCache();
                   localStorage.removeItem('user');
                   localStorage.removeItem('jwt');
                 }}

--- a/Frontend/src/components/general/upload/CropImage/index.jsx
+++ b/Frontend/src/components/general/upload/CropImage/index.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useRef } from 'react';
 
-//import ReactCrop from 'react-image-crop';
+import ReactCrop from 'react-image-crop';
 import canvasPreview from './canvasPreview';
 import useDebounceEffect from './useDebounceEffect';
 
-//import 'react-image-crop/dist/ReactCrop.css';
+import 'react-image-crop/dist/ReactCrop.css';
 
 // adapted from the react-image-crop example on
 // https://www.npmjs.com/package/react-image-crop

--- a/Frontend/src/shared/services/Profile.service.js
+++ b/Frontend/src/shared/services/Profile.service.js
@@ -14,6 +14,10 @@ const ProfileService = MOCK_PROFILE ? MockProfileService : {
     _cachedProfile.id = _cachedProfile._id;
     return _cachedProfile;
   },
+
+  clearProfileCache: () => {
+    _cachedProfile = null;
+  },
 };
 
 export default ProfileService;


### PR DESCRIPTION
Fixes bug reported by @cemostro:

> So here's a potential bug I found, when you log in, log back out and then log in again as a different user, you still get the profile of the previous user you logged in as, due to profile caching.