### PR TITLE
Fix/b-teams-combine-ids

### DIFF
--- a/Backend/src/API/REST/routes/team/teamRouter.ts
+++ b/Backend/src/API/REST/routes/team/teamRouter.ts
@@ -620,11 +620,11 @@ const get_members_of_team = (): Router => {
   router.get("/teams/:id/members", check_auth(), async (req: Request, res: Response) => {
     const teamId = req.params.id;
     try {
-      const team = await TeamService.getMembersOfTeam(teamId);
-      if (team == null) {
+      const members = await TeamService.getMembersOfTeam(teamId);
+      if (members == null) {
         return res.status(404).send(`Team ${teamId} not found`);
       }
-      return res.status(200).send(team.memberIds);
+      return res.status(200).send(members);
     } catch (err) {
       console.error(JSON.stringify(err));
       return res.status(500).json({ error: "General server error" });

--- a/Backend/src/API/REST/routes/team/teamRouter.ts
+++ b/Backend/src/API/REST/routes/team/teamRouter.ts
@@ -335,7 +335,6 @@ const join_member = (): Router => {
           return res.status(500).send("Error when joining a new member into the team.");
 
         const teamRes = await TeamService.getTeamById(teamId);
-        teamRes.memberIds.push(...teamRes.adminIds);
 
         return res.status(200).json(teamRes);
       } catch (err) {
@@ -390,7 +389,6 @@ const add_team_to_institution = (): Router => {
           return res.status(400).send("Error when associating the team with the institution.");
 
         const team2 = await TeamService.getTeamById(teamId);
-        team2.memberIds.push(...team2.adminIds);
         return res.status(200).json(team2);
       } catch (err) {
         console.error("Error when trying to join the team into the institution.");
@@ -447,7 +445,6 @@ const remove_team_from_institution = (): Router => {
           return res.status(400).send("Error when removing the team from the institution.");
 
         const team = await TeamService.getTeamById(teamId);
-        team.memberIds.push(...team.adminIds);
         return res.status(200).json(team);
       } catch (err) {
         console.error("Error when trying to join the team into the institution.");
@@ -502,7 +499,6 @@ const disjoin_member = (): Router => {
           return res.status(500).send("Error when removing a member from the team.");
 
         const teamRes = await TeamService.getTeamById(teamId);
-        teamRes.memberIds.push(...teamRes.adminIds);
         return res.status(200).json(teamRes);
       } catch (err) {
         console.error("Error when trying to remove a member from a team.");
@@ -532,6 +528,7 @@ const get_teams = (): Router => {
       if (teams != null) return res.status(200).json(teams);
       return res.status(404).send(`No teams found`);
     } catch (err) {
+      console.error(err);
       console.error(JSON.stringify(err));
       return res.status(500).send(`Internal server error`);
     }

--- a/Backend/src/API/REST/routes/team/teamRouter.ts
+++ b/Backend/src/API/REST/routes/team/teamRouter.ts
@@ -57,7 +57,7 @@ const create_team = (): Router => {
 
         const newTeam = await TeamService.addTeam(teamToAdd);
 
-        return res.status(201).json(newTeam);
+        return res.status(201).json(TeamService.mergeAdminsMembers(newTeam));
       } else {
         const teamToAdd: AddTeamDTO = {
           title,
@@ -68,7 +68,7 @@ const create_team = (): Router => {
         };
         const newTeam = await TeamService.addTeam(teamToAdd);
 
-        return res.status(201).json(newTeam);
+        return res.status(201).json(TeamService.mergeAdminsMembers(newTeam));
       }
     } catch (err) {
       console.error("Error registering team!");

--- a/Backend/src/API/REST/routes/team/teamRouter.ts
+++ b/Backend/src/API/REST/routes/team/teamRouter.ts
@@ -336,7 +336,7 @@ const join_member = (): Router => {
 
         const teamRes = await TeamService.getTeamById(teamId);
 
-        return res.status(200).json(teamRes);
+        return res.status(200).json(TeamService.mergeAdminsMembers(teamRes));
       } catch (err) {
         console.error("Error when trying to join a new member into a given team.");
         console.error(JSON.stringify(err));
@@ -389,7 +389,7 @@ const add_team_to_institution = (): Router => {
           return res.status(400).send("Error when associating the team with the institution.");
 
         const team2 = await TeamService.getTeamById(teamId);
-        return res.status(200).json(team2);
+        return res.status(200).json(TeamService.mergeAdminsMembers(team2));
       } catch (err) {
         console.error("Error when trying to join the team into the institution.");
         console.error(JSON.stringify(err));
@@ -445,7 +445,7 @@ const remove_team_from_institution = (): Router => {
           return res.status(400).send("Error when removing the team from the institution.");
 
         const team = await TeamService.getTeamById(teamId);
-        return res.status(200).json(team);
+        return res.status(200).json(TeamService.mergeAdminsMembers(team));
       } catch (err) {
         console.error("Error when trying to join the team into the institution.");
         console.error(JSON.stringify(err));
@@ -499,7 +499,7 @@ const disjoin_member = (): Router => {
           return res.status(500).send("Error when removing a member from the team.");
 
         const teamRes = await TeamService.getTeamById(teamId);
-        return res.status(200).json(teamRes);
+        return res.status(200).json(TeamService.mergeAdminsMembers(teamRes));
       } catch (err) {
         console.error("Error when trying to remove a member from a team.");
         console.error(JSON.stringify(err));
@@ -525,7 +525,7 @@ const get_teams = (): Router => {
     try {
       const teams = await TeamService.getTeams(query);
 
-      if (teams != null) return res.status(200).json(teams);
+      if (teams != null) return res.status(200).json(TeamService.mergeAdminsMembers(teams));
       return res.status(404).send(`No teams found`);
     } catch (err) {
       console.error(err);
@@ -544,7 +544,7 @@ const get_users_teams = (): Router => {
     try {
       const teams = await TeamService.getUsersTeams(userId);
 
-      if (teams != null) return res.status(200).json(teams);
+      if (teams != null) return res.status(200).json(TeamService.mergeAdminsMembers(teams));
       res.status(404).send(`No teams found`);
     } catch (err) {
       console.error(JSON.stringify(err));
@@ -561,7 +561,7 @@ const get_team = (): Router => {
     try {
       const team = await TeamService.getTeamById(teamsId);
 
-      if (team != null) return res.status(200).json(team);
+      if (team != null) return res.status(200).json(TeamService.mergeAdminsMembers(team));
       return res.status(404).send(`Team ${teamsId} not found`);
     } catch (err) {
       console.error(JSON.stringify(err));
@@ -624,10 +624,10 @@ const get_members_of_team = (): Router => {
       if (members == null) {
         return res.status(404).send(`Team ${teamId} not found`);
       }
-      return res.status(200).send(members);
+      return res.status(200).send(TeamService.mergeAdminsMembers(members).memberIds);
     } catch (err) {
       console.error(JSON.stringify(err));
-      return res.status(500).json({ error: "General server error" });
+      return res.status(500).json({ error: "Internal server error" });
     }
   });
   return router;

--- a/Backend/src/database/services/team.service.ts
+++ b/Backend/src/database/services/team.service.ts
@@ -1,4 +1,5 @@
 import { ITeam, teamModel } from "../models/team";
+import { IUser } from "../models/user";
 import { AddTeamDTO, UpdateTeamDTO } from "../dtos/team.dto";
 import { ObjectId } from "mongoose";
 
@@ -83,12 +84,11 @@ export default class TeamService {
     );
   }
 
-  static async getMembersOfTeam(team_id: ObjectId | string): Promise<ITeam | null> {
-    //For some reason, transform() is not included in mongoose definitions (found it in online documentation)
-    // => cast to any as a workaround
-    return await (teamModel.findById(team_id) as any)
-      .transform(TeamService.mergeMemberIds)
-      .populate("memberIds");
+  static async getMembersOfTeam(team_id: ObjectId | string): Promise<Array<IUser> | null> {
+    return TeamService.mergeMemberIds(
+      await teamModel.findById(team_id).populate("memberIds").populate("adminIds")
+    ).memberIds as any as Array<IUser>;
+    //Cast Array<ObjectId> to Array<IUser> as populate changes the type of elements of memberIds
   }
 
   /**


### PR DESCRIPTION
fill memberIds with adminIds in ALL team responses in teams router
Undo population of memberIds in all routes except /team/:id/members