### PR TITLE
Hiding projects from private and by institution teams

### DIFF
--- a/Frontend/src/components/teams/detail/TeamProjectList/index.jsx
+++ b/Frontend/src/components/teams/detail/TeamProjectList/index.jsx
@@ -28,7 +28,7 @@ function TeamProjectList({
   if ((!team.memberIds?.includes(user._id) && team.visibility === 'PRIVATE')
     || (team.visibility === 'BY_INSTITUTION' && !institution.memberIds?.includes(user._id))) {
     return (
-      <span>{`The projects of this team are hidden as it's visibility is set to ${team.visibility.toLowerCase().replace('_', ' ')} and you're not a member of this team${team.visibility === 'BY_INSTITUTION' ? " or you're a member of this team's institution" : ''}.`}</span>
+      <span>{`The projects of this team are hidden as it's visibility is set to ${team.visibility.toLowerCase().replace('_', ' ')} and you're not a member of this team${team.visibility === 'BY_INSTITUTION' ? " or this team's institution" : ''}.`}</span>
     );
   }
 

--- a/Frontend/src/components/teams/detail/TeamProjectList/index.jsx
+++ b/Frontend/src/components/teams/detail/TeamProjectList/index.jsx
@@ -11,7 +11,9 @@ import AtlasService from 'shared/services/Atlas.service';
 import ModelService from 'shared/services/Model.service';
 import TeamService from 'shared/services/Team.service';
 
-function TeamProjectList({ team, isAdmin, updateTeam }) {
+function TeamProjectList({
+  team, institution, user, isAdmin, updateTeam,
+}) {
   const [projects, setProjects] = useState([]);
   const [atlases, setAtlases] = useState([]);
   const [models, setModels] = useState([]);
@@ -22,6 +24,13 @@ function TeamProjectList({ team, isAdmin, updateTeam }) {
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [removedProject, setRemovedProject] = useState([]);
   const [errorMessage, setErrorMessage] = useState('');
+
+  if ((!team.memberIds?.includes(user._id) && team.visibility === 'PRIVATE')
+    || (team.visibility === 'BY_INSTITUTION' && !institution.memberIds?.includes(user._id))) {
+    return (
+      <span>{`The projects of this team are hidden as it's visibility is set to ${team.visibility.toLowerCase().replace('_', ' ')} and you're not a member of this team${team.visibility === 'BY_INSTITUTION' ? " or you're a member of this team's institution" : ''}.`}</span>
+    );
+  }
 
   const handleCloseDialog = () => setDialogOpen(false);
 

--- a/Frontend/src/components/teams/detail/TeamUserHeaderRight/index.jsx
+++ b/Frontend/src/components/teams/detail/TeamUserHeaderRight/index.jsx
@@ -34,7 +34,7 @@ function TeamUserHeaderRight({
     || (team.invitedMemberIds?.includes(user._id));
 
   return (
-    <Tooltip title={canJoin ? '' : `This team is ${team.visibility.toLowerCase().replace('_', ' ')} and you haven't been invited${team.visibility === 'BY_INSTITUTION' ? " or you're a member of this team's institution" : ''}.`}>
+    <Tooltip title={canJoin ? '' : `This team is ${team.visibility.toLowerCase().replace('_', ' ')} and you haven't been invited${team.visibility === 'BY_INSTITUTION' ? " and you're not a member of this team's institution" : ''}.`}>
       <div>
         <TeamJoinButton
           isDisabled={!canJoin}

--- a/Frontend/src/views/TeamPage/index.jsx
+++ b/Frontend/src/views/TeamPage/index.jsx
@@ -130,6 +130,8 @@ export default function TeamPage() {
         <hr />
         <TeamProjectList
           team={team}
+          institution={institution}
+          user={user}
           isAdmin={isAdmin}
           updateTeam={() => updateTeam(true)}
         />


### PR DESCRIPTION
This PR hides the projects of a team if the visibility is set to private and you're not a member/ set to by institution and you're not a member of the institution and says the following messages:
"The projects of this team are hidden as it's visibility is set to private and you're not a member of this team."
or
"The projects of this team are hidden as it's visibility is set to by institution and you're not a member of this team or this team's institution."