### PR TITLE
Team description edit, project info and Invite button color changes

### DIFF
--- a/Frontend/src/components/institutions/InstitutionInviteButton/index.jsx
+++ b/Frontend/src/components/institutions/InstitutionInviteButton/index.jsx
@@ -52,15 +52,17 @@ function InstitutionInviteButton({ institution }) {
           setInvitedMailAdress('');
           setMailError('');
         }}
-        color="primary"
         aria-label="add"
         sx={{
           position: 'fixed',
           bottom: '3%',
           right: '2%',
         }}
+        style={{
+          backgroundColor: '#5676E4'
+        }}
       >
-        <PersonAddOutlinedIcon />
+        <PersonAddOutlinedIcon style={{ color: 'white' }} />
       </Fab>
       <Modal
         isOpen={dialogOpen}

--- a/Frontend/src/components/teams/detail/TeamInviteButton/index.jsx
+++ b/Frontend/src/components/teams/detail/TeamInviteButton/index.jsx
@@ -18,11 +18,10 @@ function TeamInviteButton({ team }) {
 
   const handleCloseDialog = () => setDialogOpen(false);
 
-  function validateEmail(email) 
-    {
-        let re = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
-        return re.test(email);
-    }
+  function validateEmail(email) {
+    let re = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+    return re.test(email);
+  }
 
   async function handleTeamInvite() {
     if (!invitedMailAdress || !validateEmail(invitedMailAdress)) {
@@ -56,15 +55,17 @@ function TeamInviteButton({ team }) {
           setInvitedMailAdress('');
           setMailError('');
         }}
-        color="primary"
         aria-label="add"
         sx={{
           position: 'fixed',
           bottom: '3%',
           right: '2%',
         }}
+        style={{
+          backgroundColor: '#5676E4'
+        }}
       >
-        <PersonAddOutlinedIcon />
+        <PersonAddOutlinedIcon style={{ color: 'white' }} />
       </Fab>
       <Modal
         isOpen={dialogOpen}

--- a/Frontend/src/components/teams/detail/TeamProjectList/index.jsx
+++ b/Frontend/src/components/teams/detail/TeamProjectList/index.jsx
@@ -66,7 +66,9 @@ function TeamProjectList({
   if (!team.memberIds?.includes(user._id) && ((team.visibility === 'PRIVATE')
     || (team.visibility === 'BY_INSTITUTION' && !institution.memberIds?.includes(user._id)))) {
     return (
-      <span>{`The projects of this team are hidden as it's visibility is set to ${team.visibility.toLowerCase().replace('_', ' ')} and you're not a member of this team${team.visibility === 'BY_INSTITUTION' ? " or this team's institution" : ''}.`}</span>
+      <Alert severity="warning">
+        {`The projects of this team are hidden as it's visibility is set to ${team.visibility.toLowerCase().replace('_', ' ')} and you're not a member of this team${team.visibility === 'BY_INSTITUTION' ? " or this team's institution" : ''}.`}
+      </Alert>
     );
   }
 
@@ -75,7 +77,11 @@ function TeamProjectList({
   }
 
   if (projects.length === 0) {
-    return (<span>No projects.</span>);
+    return (
+      <Alert severity="info">
+        This team does not have any projects yet. Members can add one of their projects from the Gene Mapper page.
+      </Alert>
+    );
   }
 
   return (

--- a/Frontend/src/components/teams/detail/TeamProjectList/index.jsx
+++ b/Frontend/src/components/teams/detail/TeamProjectList/index.jsx
@@ -67,7 +67,7 @@ function TeamProjectList({
     || (team.visibility === 'BY_INSTITUTION' && !institution.memberIds?.includes(user._id)))) {
     return (
       <Alert severity="warning">
-        {`The projects of this team are hidden as it's visibility is set to ${team.visibility.toLowerCase().replace('_', ' ')} and you're not a member of this team${team.visibility === 'BY_INSTITUTION' ? " or this team's institution" : ''}.`}
+        {`The projects of this team are hidden as its visibility is set to ${team.visibility.toLowerCase().replace('_', ' ')} and you're not a member of this team${team.visibility === 'BY_INSTITUTION' ? " or this team's institution" : ''}.`}
       </Alert>
     );
   }

--- a/Frontend/src/views/TeamPage/index.jsx
+++ b/Frontend/src/views/TeamPage/index.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import styles from './teamPage.module.css';
 import HeaderView from 'components/general/HeaderView';
 import TeamProjectList from 'components/teams/detail/TeamProjectList';
 import TeamMemberList from 'components/teams/detail/TeamMemberList';
@@ -10,11 +9,11 @@ import TeamHeaderOptions from 'components/teams/detail/TeamHeaderOptions';
 import TeamService from 'shared/services/Team.service';
 import InstitutionService from 'shared/services/Institution.service';
 import TeamInviteButton from 'components/teams/detail/TeamInviteButton';
-import TextField from '@mui/material/TextField';
+import { TextField, Snackbar, Alert } from '@mui/material';
 import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import { useAuth } from 'shared/context/authContext';
-import Snackbar from '@mui/material/Snackbar';
-import Alert from '@mui/material/Alert';
+import Button from 'components/CustomButton';
 
 export default function TeamPage() {
   const { id } = useParams();
@@ -22,7 +21,7 @@ export default function TeamPage() {
   const [user] = useAuth();
   const [institution, setInstitution] = useState({});
   const [newDescription, setNewDescription] = useState('');
-  const [descriptionChanged, setDescriptionChanged] = useState(false);
+  const [editMode, setEditMode] = useState(false);
   const [open, setOpen] = useState(false);
 
   const handleClose = (event, reason) => {
@@ -34,7 +33,6 @@ export default function TeamPage() {
 
   const handleDescriptionChange = (event) => {
     event.preventDefault();
-    setDescriptionChanged(true);
     setNewDescription(event.target.value);
   };
 
@@ -51,9 +49,13 @@ export default function TeamPage() {
   }
 
   async function updateDescription() {
+    if (!editMode) {
+      setEditMode(true);
+      return;
+    }
     await TeamService.changeTeamDescription(id, newDescription);
     updateTeam(true);
-    setDescriptionChanged(false);
+    setEditMode(false);
     setOpen(true);
   }
 
@@ -66,7 +68,6 @@ export default function TeamPage() {
     setNewDescription(team.description);
   }, [team]);
 
-  // Institution may be undefined
   useEffect(() => {
     if (Object.keys(team).length !== 0) {
       InstitutionService.getInstitution(team.institutionId)
@@ -97,15 +98,20 @@ export default function TeamPage() {
       <br />
       <section>
         {isAdmin && (
-          <button
-            className={styles.editDetailsButton}
-            type="button"
+          <Button
+            sx={{
+              position: "static",
+              alignItems: "center",
+              float: "right",
+            }}
+            type={editMode ? "secondary" : "primary"}
             onClick={() => updateDescription()}
-            disabled={descriptionChanged ? '' : 'disabled'}
           >
-            <span>Save Edits</span>
-            <SaveOutlinedIcon fontSize="small" />
-          </button>
+            {editMode && (<div><span>Save Edits</span>
+              <SaveOutlinedIcon sx={{ fontSize: 15, marginLeft: "5px" }} /></div>)}
+            {!editMode && (<div><span>Edit Description</span>
+              <EditOutlinedIcon sx={{ fontSize: 15, marginLeft: "5px" }} /></div>)}
+          </Button>
         )}
         <h2>Description</h2>
         <hr />
@@ -117,7 +123,7 @@ export default function TeamPage() {
             maxRows={5}
             value={newDescription}
             InputProps={{
-              readOnly: !isAdmin,
+              readOnly: !editMode,
             }}
             fullWidth
             onChange={handleDescriptionChange}

--- a/Frontend/src/views/TeamPage/index.jsx
+++ b/Frontend/src/views/TeamPage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import HeaderView from 'components/general/HeaderView';
 import TeamProjectList from 'components/teams/detail/TeamProjectList';
@@ -23,6 +23,8 @@ export default function TeamPage() {
   const [newDescription, setNewDescription] = useState('');
   const [editMode, setEditMode] = useState(false);
   const [open, setOpen] = useState(false);
+
+  const descriptionRef = useRef();
 
   const handleClose = (event, reason) => {
     if (reason === 'clickaway') {
@@ -51,6 +53,7 @@ export default function TeamPage() {
   async function updateDescription() {
     if (!editMode) {
       setEditMode(true);
+      descriptionRef.current.focus();
       return;
     }
     await TeamService.changeTeamDescription(id, newDescription);
@@ -118,6 +121,7 @@ export default function TeamPage() {
         <div>
           <TextField
             id="description"
+            inputRef={descriptionRef}
             multiline
             minRows={3}
             maxRows={5}

--- a/Frontend/src/views/TeamPage/teamPage.module.css
+++ b/Frontend/src/views/TeamPage/teamPage.module.css
@@ -5,15 +5,3 @@
 .cardSpacing {
     margin-bottom: 16px;
 }
-
-.editDetailsButton {
-    position: static;
-    border: none;
-    background-color: #002744;
-    color: white;
-    padding: 5px 8px;
-    font-size: 12px;
-    align-items: center;
-    cursor: pointer;
-    float: right;
-  }


### PR DESCRIPTION
This PR changes how team descriptions are modified. Now you first click on a "Edit Description" button, which makes the description field editable. Then this button changes to "Save Edits" and you can  save your changes. F2 Button styles are used. 
The invite buttons for team and institution pages now follow the general color palette.
There's a nicer looking alert instead of just text for info when team has no projects/they are hidden