### PR TITLE
minor API usage adaption to a change for leaving teams/institutions

### DIFF
--- a/Frontend/src/shared/services/Institution.service.js
+++ b/Frontend/src/shared/services/Institution.service.js
@@ -39,9 +39,8 @@ const InstitutionService = MOCK_INSTUTITIONS ? MockInstitutionService : {
   },
 
   async leaveInstitution(institutionId) {
-    const user = await ProfileService.getProfile();
     try {
-      await axiosInstance.delete(`/institutions/${institutionId}/join`, { data: { userId: user.id } });
+      await axiosInstance.delete(`/institutions/${institutionId}/join`);
     } catch (e) {
       throw Error(e.response.data);
     }
@@ -82,7 +81,7 @@ const InstitutionService = MOCK_INSTUTITIONS ? MockInstitutionService : {
 
   async removeMemberFromInstitution(institutionId, memberId) {
     try {
-    await axiosInstance.delete(`/institutions/${institutionId}/members/${memberId}`);
+      await axiosInstance.delete(`/institutions/${institutionId}/members/${memberId}`);
     } catch (e) {
       throw Error(e.response.data);
     }
@@ -94,7 +93,7 @@ const InstitutionService = MOCK_INSTUTITIONS ? MockInstitutionService : {
 
   async removeInstitutionAdmin(institutionId, memberId) {
     await axiosInstance.delete(`/institutions/${institutionId}/admins/${memberId}`);
-  }
+  },
 };
 
 export default InstitutionService;

--- a/Frontend/src/shared/services/Team.service.js
+++ b/Frontend/src/shared/services/Team.service.js
@@ -11,9 +11,8 @@ function enhanceTeam(team) {
 
 const TeamService = MOCK_TEAMS ? MockTeamService : {
   async leaveTeam(teamId) {
-    const user = await ProfileService.getProfile();
     try {
-      await axiosInstance.delete(`/teams/${teamId}/join`, { data: { userId: user.id } });
+      await axiosInstance.delete(`/teams/${teamId}/join`);
     } catch (e) {
       throw Error(e.response.data);
     }
@@ -89,7 +88,6 @@ const TeamService = MOCK_TEAMS ? MockTeamService : {
     const { data } = await axiosInstance.put(`/teams/${teamId}`, { visibility });
     return data;
   },
-
 
   async getInstitutionTeams(institutionId) {
     const { data } = await axiosInstance.get(`/institutions/${institutionId}/teams`);


### PR DESCRIPTION
I discussed with @FabianNowak how the API for leaving an institution / team _should_ be (because it somehow broke anyways and we wanted to do it right this time). Now the `DELETE` request does not have any parameters anymore.