### PR TITLE
remove check_auth in query upload and download

### DIFF
--- a/Backend/src/API/REST/routes/file_download/results.ts
+++ b/Backend/src/API/REST/routes/file_download/results.ts
@@ -9,7 +9,7 @@ import { result_path } from "../file_upload/bucket_filepaths";
 
 export default function download_results_route() {
   let router = express.Router();
-  router.post("/file_download/results", validationMdw, check_auth(), async (req: ExtRequest, res) => {
+  router.post("/file_download/results", validationMdw, async (req: ExtRequest, res) => { // removed check_auth() middleware in order to use in non-login version
     let { id } = req.body;
     try {
       if (!process.env.S3_BUCKET_NAME) {

--- a/Backend/src/API/REST/routes/file_upload/complete_upload.ts
+++ b/Backend/src/API/REST/routes/file_upload/complete_upload.ts
@@ -26,7 +26,7 @@ export default function upload_complete_upload_route() {
   router.post(
     "/file_upload/complete_upload",
     validationMdw,
-    check_auth(),
+    //check_auth(), removed auth check in order to use in non-login version
     async (req: ExtRequest, res) => {
       let { parts, uploadId } = req.body;
       if (!process.env.S3_BUCKET_NAME)

--- a/Backend/src/API/REST/routes/file_upload/get_upload_url.ts
+++ b/Backend/src/API/REST/routes/file_upload/get_upload_url.ts
@@ -8,7 +8,7 @@ import express from "express";
 export default function upload_get_upload_url_route() {
   let router = express.Router();
 
-  router.get("/file_upload/get_upload_url", check_auth(), async (req: ExtRequest, res) => {
+  router.get("/file_upload/get_upload_url", async (req: ExtRequest, res) => { // removed check_auth() in order to use in non-login version
     let { partNumber, uploadId } = req.query;
     if (!process.env.S3_BUCKET_NAME) return res.status(500).send("S3-BucketName is not set");
 

--- a/Backend/src/API/REST/routes/file_upload/start_upload.ts
+++ b/Backend/src/API/REST/routes/file_upload/start_upload.ts
@@ -13,7 +13,7 @@ export default function upload_start_upload_route() {
   router.post(
     "/file_upload/start_upload",
     validationMdw,
-    check_auth(),
+    // check_auth(), removed auth check for the file upload in order to use in non-login version
     async (req: ExtRequest, res) => {
       let { projectName, atlasId, modelId, fileName } = req.body;
       if (!process.env.S3_BUCKET_NAME) {

--- a/Backend/src/API/REST/routes/project/projectRouter.ts
+++ b/Backend/src/API/REST/routes/project/projectRouter.ts
@@ -39,7 +39,7 @@ const get_projects = (): Router => {
 const get_userProjects = (): Router => {
   let router = express.Router();
 
-  router.get("/ownprojects", check_auth(), async (req: ExtRequest, res: any) => {
+  router.get("/ownprojects", async (req: ExtRequest, res: any) => { // check_auth() removed in order to use in non-login version
     try {
       const { sort, ...rest } = req.params;
       let sortParam: number;


### PR DESCRIPTION
Removed the check_auth() middleware call in routes needed for the non-logged-in version of the genemapper. 
Nothing was changed other than that, so should be safe to merge. 

Can you deploy after merging?